### PR TITLE
Fix API auth bug, and show apiKey at /profile

### DIFF
--- a/controllers/application_controller.js
+++ b/controllers/application_controller.js
@@ -84,12 +84,7 @@ ApplicationController.authenticate = function(req, res, next) {
         req.user = user;
         var reqPath = '/' + oauthConfig.profilePath +
           '?access_token=' + user.accessToken;
-        var authGet = http.get(
-          {
-            host: oauthConfig.server,
-            port: 3002,
-            path: reqPath
-          } , function (authRes) {
+        var authGet = http.get(oauthConfig.server + reqPath, function (authRes) {
             authRes.setEncoding('utf8');
             authRes.on('data', function(data){
               if (JSON.parse(data).username === user.username) {

--- a/controllers/application_controller.js
+++ b/controllers/application_controller.js
@@ -7,19 +7,6 @@ var OAuth2 = require('oauth').OAuth2,
 var db = require('../models'),
     User = db.User;
 
-// HACK: dump database table to show API keys
-User
-  .findAll()
-  .error(function (e) {
-    console.error(HERE, e);
-  })
-  .success(function (arr) {
-    arr.forEach(function (user) {
-      console.log("USER", user.username, user.apiKey);
-    });
-  });
-
-
 var errors = {
   incorrectApiKey: {
     ok: false,

--- a/controllers/application_controller.js
+++ b/controllers/application_controller.js
@@ -7,6 +7,19 @@ var OAuth2 = require('oauth').OAuth2,
 var db = require('../models'),
     User = db.User;
 
+// HACK: dump database table to show API keys
+User
+  .findAll()
+  .error(function (e) {
+    console.error(HERE, e);
+  })
+  .success(function (arr) {
+    arr.forEach(function (user) {
+      console.log("USER", user.username, user.apiKey);
+    });
+  });
+
+
 var errors = {
   incorrectApiKey: {
     ok: false,

--- a/controllers/oauth_controller.js
+++ b/controllers/oauth_controller.js
@@ -44,7 +44,17 @@ OauthController.prototype.profile = function(req, res) {
   // Make an authenticated request to oauth server for our info.
   user.json('users/profile').get(function (err, json, last) {
     // json contains "username", "email", "name", and "apiKey"
-    res.send('<h1>Hello ' + json.email + '!</h1>');
+    User
+      .find({ email: json.email })
+      .error(function(err){
+        debug(err);
+        return res.json(500, errors.authentication);
+      })
+      .success(function(db_user){
+        var util= require('util'),
+            html = util.format("<h1>Hello %s!</h1>Your API key is: %s", db_user.email, db_user.apiKey);
+        res.send(html);
+      });
   });
 }
 


### PR DESCRIPTION
This does two things:
- shows apiKey in web interface after connecting via oauth
- fixes an issue that was preventing the apiKey from actually being used (since for whatever reason it still bounces through oauth server each time anyway, I guess to make sure user account is still active or something…)
